### PR TITLE
Send last message on client connect rather than broadcast

### DIFF
--- a/appointments.py
+++ b/appointments.py
@@ -128,7 +128,7 @@ async def on_connect(websocket, path):
     connected_clients.append(websocket)
     last_message['connectedClients'] = len(connected_clients)
     try:
-        websockets.broadcast(connected_clients, json.dumps(last_message))
+        await websocket.send(json.dumps(last_message))
         await websocket.wait_closed()
     finally:
         connected_clients.remove(websocket)


### PR DESCRIPTION
When a client joins the server, only that client needs the `last_message` and a broadcast to all is not really needed.

This avoid processing in the server side + makes the response frequency/events more expectable if that makes sense.