### PR TITLE
Replace requests lib with aiohttp for non-blocking appointment fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.10.0
 pytz
-requests==2.27.1
+aiohttp==3.8.1
 websockets==10.1
 lxml==4.7.1


### PR DESCRIPTION
The function that fetches appointments was blocking the main thread, mainly
because it was using the `requests` library that does not support
async/await.

That meant that during the `get_appointment` duration (which
was ~ the latency of 2 requests + 1 second of sleep) the websocket server
was not able to attend new connections and clients would need to wait until the thread was freed to establish connection.

Moving to the `aiohttp` library constantly frees the main thread so it is able to attend new
incoming connections, thus making the experience more responsive for clients