### PR TITLE
Handling asyncio timeouts

### DIFF
--- a/appointments/appointments.py
+++ b/appointments/appointments.py
@@ -137,6 +137,16 @@ async def look_for_appointments(appointments_url: str, email: str, script_id: st
             'message': 'Could not fetch results from Berlin.de - Got connection error.',
             'appointmentDates': [],
         }
+    except asyncio.exceptions.TimeoutError:
+        logger.warning(f"Got Timeout on response from Berlin.de. Checking in {refresh_delay} seconds")
+        if not quiet:
+            chime.error()
+        return {
+            'time': datetime_to_json(datetime.now()),
+            'status': 504,
+            'message': f'Could not fetch results from Berlin.de. - Timeout',
+            'appointmentDates': [],
+        }
     except Exception as err:
         logger.exception("Could not fetch results due to an unexpected error.")
         if not quiet:


### PR DESCRIPTION
Adding handling for `asyncio.exceptions.TimeoutError` exception that happening from time to time. Related to issue #14 

After the fix, timeouts are logged and do not break the terminal:
```
INFO: Server is running on port 80. Looking for appointments every 180 seconds.
INFO: Found 0 appointments: []
INFO: Found 3 appointments: ['2023-05-16T00:00:00Z', '2023-06-06T00:00:00Z', '2023-06-09T00:00:00Z']
INFO: Found 2 appointments: ['2023-06-06T00:00:00Z', '2023-06-09T00:00:00Z']
INFO: Found 2 appointments: ['2023-06-06T00:00:00Z', '2023-06-09T00:00:00Z']
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
INFO: Found 3 appointments: ['2023-04-17T00:00:00Z', '2023-06-05T00:00:00Z', '2023-06-09T00:00:00Z']
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
INFO: Found 0 appointments: []
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
WARNING: Got Timeout on response from Berlin.de. Checking in 180 seconds
```

