### PR TITLE
Implement location filter for appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ No. It's not possible due to rate-limiting by Berlin.de. [You probably don't nee
 ### I get an HTTP 403 or 418 response
 
 This means that Berlin.de is blocking you as a bot. There is nothing I can do to fix this problem. Please do not open an issue about this.
+
+### How to filter appointments by location
+
+The `service.berlin.de` website allows you to search for appointments at selected locations only.
+To use the same filter in the application, follow these steps:
+
+1. Install the script or clone the repository.
+2. Go to <https://service.berlin.de/dienstleistung/120686/>
+3. Select the required locations.
+4. Open the browser developer console (F12) and go to the Network tab.
+5. Click the “An diesem Standort einen Termin buchen” button.
+6. In the Network tab, copy the URL you were redirected to. It will look like: `tag.php?termin=...`
+7. Run the application and pass this link as the URL: `appointments --url "https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1&dienstleisterlist=122..."`

--- a/appointments/appointments.py
+++ b/appointments/appointments.py
@@ -167,8 +167,11 @@ async def watch_for_appointments(service_page_url: str, email: str, script_id: s
     global last_message
     logger.info(f"Getting appointment URL for {service_page_url}")
 
-    service_id = service_page_url.rstrip('/').split('/')[-1]
-    appointments_url = f"https://service.berlin.de/terminvereinbarung/termin/all/{service_id}/"
+    if service_page_url.startswith('https://service.berlin.de/dienstleistung'):
+        service_id = service_page_url.rstrip('/').split('/')[-1]
+        appointments_url = f"https://service.berlin.de/terminvereinbarung/termin/all/{service_id}/"
+    else:
+        appointments_url = service_page_url
 
     logger.info(f"URL found: {appointments_url}")
     async with websockets.serve(on_connect, port=server_port), async_playwright() as p:


### PR DESCRIPTION
As a user, I expect to be able to run an appointment search for my location. I'm not sure how useful the appointment search would be without filtering by location. I also don’t know the best way to implement it properly. I tried using a custom URL but encountered hardcoded values. Additionally, I'm not sure of a better way to get a link for finding appointments in a specific location. However, the current patch helped me find an appointment today